### PR TITLE
Node - need feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "knockout-deferred-updates",
+  "description": "Deferred Updates plugin for Knockout",
+  "url": "http://mbest.github.com/knockout-deferred-updates/",
+  "version": "0.0.1pre",
+  "license": "MIT",
+  "author": "Michael Best",
+  "main": "knockout-deferred-updates.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mbest/knockout-deferred-updates.git"
+  },
+  "bugs": "https://github.com/mbest/knockout-deferred-updates/issues",
+  "dependencies": {
+    "knockout": ">=2.2.0"
+  }
+}


### PR DESCRIPTION
Hello,

Now that I got AMD support, I'm back to ask for Node support :-)

I run my tests in Node for simplicity of automation (also in the browser, but less automated) and would love to elide the complication of swapping knockout/knockout-deferred-updates.

So this PR has a package.json which will enable the use of npm, but actually the way that `window.setImmediate` is referenced is a problem in Node that is probably most easily solved by using https://github.com/NobleJS/setImmediate. I took a stab at a quick fix but didn't complete anything.

Let me know what your thoughts are on this whole idea. I just stalked the contributors to Node's own package.json and see you there, so I'm optimistic that you'll agree this is useful!
- Kenn
