### PR TITLE
assign module.exports for CommonJS factory path

### DIFF
--- a/knockout-deferred-updates.js
+++ b/knockout-deferred-updates.js
@@ -8,7 +8,7 @@
 (function(factory) {
     if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
         // [1] CommonJS/Node.js
-        factory(require('knockout'));
+        module.exports = factory(require('knockout'));
     } else if (typeof define === 'function' && define.amd) {
         // [2] AMD anonymous module
         define(['knockout'], factory);


### PR DESCRIPTION
Is the failure to assign to module.exports an oversight or taking advantage of some peculiarity in the node module loader?  It causes the module to return an empty Object in my version of node (0.10.26).
